### PR TITLE
Add dress_code field to event model & flows

### DIFF
--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -168,7 +168,7 @@ export class EventController {
 
         this.eventService.setToken(token as string);
 
-        const { event_name, event_description, event_location, event_lat, event_long, event_date, event_time, event_hours, event_hours_type, sponsors_attending, check_in_window, check_in_radius, event_limit, is_hidden } = req.body;
+        const { event_name, event_description, event_location, event_lat, event_long, event_date, event_time, event_hours, event_hours_type, dress_code, sponsors_attending, check_in_window, check_in_radius, event_limit, is_hidden } = req.body;
 
         if (!event_name || !event_description || !event_location || event_lat === undefined || event_long === undefined || !event_date || !event_time || event_hours === undefined || !event_hours_type || sponsors_attending === undefined || check_in_window === undefined || check_in_radius === undefined || event_limit === undefined || is_hidden === undefined) {
             res.status(400).json({ error: 'Missing required fields' });
@@ -181,7 +181,7 @@ export class EventController {
         }
 
         try {
-            await this.eventService.addEvent(event_name, event_date, event_location, event_description, event_lat, event_long, event_time, event_hours, event_hours_type, sponsors_attending, check_in_window, check_in_radius, event_limit, is_hidden);
+            await this.eventService.addEvent(event_name, event_date, event_location, event_description, event_lat, event_long, event_time, event_hours, event_hours_type, dress_code?.trim() || null, sponsors_attending, check_in_window, check_in_radius, event_limit, is_hidden);
             res.json("Event added successfully");
             return;
         } catch (error) {
@@ -196,7 +196,7 @@ export class EventController {
      * @returns 
      */
     async editEvent(req: Request, res: Response) {
-        const { event_id, name, date, location, description, time, sponsors, event_hours, event_hours_type, check_in_window, check_in_radius, event_limit, is_hidden } = req.body;
+        const { event_id, name, date, location, description, time, sponsors, event_hours, event_hours_type, dress_code, check_in_window, check_in_radius, event_limit, is_hidden } = req.body;
 
         const token = extractToken(req);
         
@@ -214,7 +214,7 @@ export class EventController {
         }
         
         // Build an update object only with non-empty fields
-        const updateFields: Record<string, any> = {};
+        const updateFields: Record<string, unknown> = {};
         if (name && name.trim() !== '') {
             updateFields.event_name = name;
         }
@@ -250,6 +250,9 @@ export class EventController {
                 return;
             }
             updateFields.event_hours_type = event_hours_type;
+        }
+        if (dress_code !== undefined) {
+            updateFields.dress_code = typeof dress_code === 'string' ? dress_code.trim() : dress_code;
         }
 
         // convert check_in_window from string to number

--- a/src/services/eventService.ts
+++ b/src/services/eventService.ts
@@ -67,7 +67,8 @@ export class EventService {
     return {
       id: event.id,
       event_name: event.event_name,
-      event_date: event.event_date
+      event_date: event.event_date,
+      dress_code: event.dress_code
     };
   }
 
@@ -96,6 +97,7 @@ export class EventService {
       event_time: event.event_time,
       event_hours: event.event_hours,
       event_hours_type: event.event_hours_type,
+      dress_code: event.dress_code,
       sponsors_attending: event.sponsors_attending || [],
       check_in_window: event.check_in_window,
       event_limit: event.event_limit,
@@ -129,6 +131,7 @@ export class EventService {
       event_time: event.event_time,
       event_hours: event.event_hours,
       event_hours_type: event.event_hours_type,
+      dress_code: event.dress_code,
       sponsors_attending: event.sponsors_attending || [],
       check_in_window: event.check_in_window,
       event_limit: event.event_limit,
@@ -209,7 +212,7 @@ export class EventService {
     }
   }
 
-  async addEvent(name: string, date: string, location: string, description: string, lat: number, long: number, time: string, hours: number, hours_type: string, sponsors: string[], check_in_window: number, check_in_radius: number, event_limit: number, is_hidden: boolean) {
+  async addEvent(name: string, date: string, location: string, description: string, lat: number, long: number, time: string, hours: number, hours_type: string, dress_code: string | null, sponsors: string[], check_in_window: number, check_in_radius: number, event_limit: number, is_hidden: boolean) {
     const { data, error } = await this.supabase
         .from('events')
         .insert(
@@ -217,6 +220,7 @@ export class EventService {
               event_time: time,
               event_hours: hours,
               event_hours_type: hours_type,
+              dress_code: dress_code,
               event_name: name,
               event_date: date,
               event_location: location,
@@ -234,7 +238,7 @@ export class EventService {
     return data;
   }
 
-  async editEvent(event_id: string, updateData: Record<string, any>) {
+  async editEvent(event_id: string, updateData: Record<string, unknown>) {
     const { data, error } = await this.supabase
       .from("events")
       .update(updateData)

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -22,6 +22,7 @@ export interface SupabaseEventResponse {
   event_time: string;
   event_hours: number;
   event_hours_type: string;
+  dress_code: string | null;
   sponsors_attending: string[] | null;
   check_in_window: number;
   event_limit: number;
@@ -41,6 +42,7 @@ export interface Event {
   event_time: string;
   event_hours: number;
   event_hours_type: string;
+  dress_code?: string | null;
   sponsors_attending: string[];
   check_in_window: number;
   event_limit: number;
@@ -59,6 +61,7 @@ export interface PublicEvent {
   id: number;
   event_name: string;
   event_date: string;
+  dress_code?: string | null;
 }
 
 // Member view - no PII, geolocation only if user RSVP'd
@@ -73,6 +76,7 @@ export interface MemberEvent {
   event_time: string;
   event_hours: number;
   event_hours_type: string;
+  dress_code?: string | null;
   sponsors_attending: string[];
   check_in_window: number;
   event_limit: number;


### PR DESCRIPTION
Add optional dress_code support across the event stack: controllers, service, and types. The controller now accepts dress_code from requests (trims string or sets null) and includes it when creating/updating events; update payload typing was tightened from any to unknown. The service persists and returns dress_code in DB inserts and mapped responses. Type definitions (SupabaseEventResponse, Event, PublicEvent, MemberEvent) were updated to include dress_code. Also minor newline/formatting cleanup.